### PR TITLE
Add RaspberryPi-GPIO-Manager-Frontend to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Do not forget to read the official [blog](https://blog.quasar.dev/).
 
 | Name | Links | Description | Quasar |
 | --- | --- | --- | --- |
+| RaspberryPi-GPIO-Manager-Frontend | [github](https://github.com/jk-powered-de/RaspberryPi-GPIO-Manager-Frontend) | Opensource RaspberryPi GPIO Manager Frontend based on Vue.js/Quasar for RaspberryPi GPIO Manager Backend | v2.2.3 |
 | Gobazar.uz | [website](https://gobazar.uz) | The first big e-commerce website made with Vue.js/Quasar | v1 |
 | Quasar Gaming Template | [github](https://github.com/pratik227/quasar-gaming), [website](https://quasar-gaming.netlify.app/) | Free Quasar Gaming Template based on Vue js and Quasar Framework. | v1.12.12 |
 | Kudos - Company profile template | [github](https://github.com/mayank091193/vue-quasar-company-profile-website), [website](https://quasar-company-profile-template.netlify.app/) | Free template for company profile made using Quasar Framework and Vue.js! It is a fully responsive template which you can use for your company or may be for your own portfolio website. | v1.9.15 |


### PR DESCRIPTION
This commit adds the RaspberryPi-GPIO-Manager-Frontend (OpenSource) Project to Quasar projects list. 

https://github.com/jk-powered-de/RaspberryPi-GPIO-Manager-Frontend