### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Do not forget to read the official [blog](https://blog.quasar.dev/).
 | Starter kit | [github](https://github.com/MilosPaunovic/quasar-v2-starter) | Starter kit for quickly lifting your project from the ground up; includes public pages (Login, Register, Reset Password), Router & Pinia are present with a lot more helpful stuff implemented. | v2 |
 | OTA system | [github](https://github.com/Cap-go/capacitor-updater) | Auto update system for mobile app, send update to users without app store review | v2 |
 | Quasar Firebase Template | [github](https://github.com/wiktorcie/quasar2-firebase-auth), [demo](https://xenodochial-clarke-616008.netlify.app/#/) | Email/google sign in, user profiles, password resets, photo uploads to Google Firebase | v2.0.3 |
-| Cabloy-Front | [github](https://github.com/cabloy/cabloy-front/tree/main/cabloy-front-quasar) | A vue3 framework with ioc container. No `ref/reactive`, no `ref.value`, no `pinia` | v2.16.4 |
+| @cabloy/front-quasar | [github](https://github.com/cabloy/cabloy-front/tree/main/cabloy-front-quasar) | A vue3 framework with ioc container. No `ref/reactive`, no `ref.value`, no `pinia` | v2.16.4 |
 
 # Projects Using Quasar
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Do not forget to read the official [blog](https://blog.quasar.dev/).
 | Starter kit | [github](https://github.com/MilosPaunovic/quasar-v2-starter) | Starter kit for quickly lifting your project from the ground up; includes public pages (Login, Register, Reset Password), Router & Pinia are present with a lot more helpful stuff implemented. | v2 |
 | OTA system | [github](https://github.com/Cap-go/capacitor-updater) | Auto update system for mobile app, send update to users without app store review | v2 |
 | Quasar Firebase Template | [github](https://github.com/wiktorcie/quasar2-firebase-auth), [demo](https://xenodochial-clarke-616008.netlify.app/#/) | Email/google sign in, user profiles, password resets, photo uploads to Google Firebase | v2.0.3 |
+| Cabloy-Front | [github](https://github.com/cabloy/cabloy-front/tree/main/cabloy-front-quasar) | A vue3 framework with ioc container. No `ref/reactive`, no `ref.value`, no `pinia` | v2.16.4 |
 
 # Projects Using Quasar
 


### PR DESCRIPTION
@cabloy/front-quasar is a vue3 framework with ioc container. No `ref/reactive`, no `ref.value`, no `pinia`.